### PR TITLE
refactor to reduce size of `Uri`

### DIFF
--- a/src/absolute_uri.rs
+++ b/src/absolute_uri.rs
@@ -17,13 +17,13 @@ impl AbsoluteUri {
 
     /// Borrow the authority (if any) of the URI.
     #[must_use = "authority not used"]
-    pub fn authority(&self) -> Option<&Authority> {
+    pub fn authority(&self) -> Option<Authority> {
         self.uri.authority()
     }
 
     /// Borrow the fragment (if any) of the URI.
     #[must_use]
-    pub fn fragment(&self) -> Option<&[u8]> {
+    pub fn fragment(&self) -> Option<Vec<u8>> {
         self.uri.fragment()
     }
 
@@ -41,7 +41,7 @@ impl AbsoluteUri {
 
     /// Borrow the host portion of the Authority (if any) of the URI.
     #[must_use]
-    pub fn host(&self) -> Option<&[u8]> {
+    pub fn host(&self) -> Option<Vec<u8>> {
         self.uri.host()
     }
 
@@ -144,7 +144,7 @@ impl AbsoluteUri {
 
     /// Borrow the query (if any) of the URI.
     #[must_use]
-    pub fn query(&self) -> Option<&[u8]> {
+    pub fn query(&self) -> Option<Vec<u8>> {
         self.uri.query()
     }
 

--- a/src/absolute_uri.rs
+++ b/src/absolute_uri.rs
@@ -3,7 +3,7 @@ use std::{borrow::Borrow, ops::Deref, string::FromUtf8Error};
 use crate::{error::MissingSchemeError, Authority, Error, Uri};
 
 /// An absolute [`Uri`]
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct AbsoluteUri {
     pub(crate) uri: Uri,
 }


### PR DESCRIPTION
Refactor `Uri` such that each part is not stored within the data structure, instead using ranges to point to the possible components segments within the raw string.

This will mean that each request for the parts, e.g. `host`, will need to be decoded so that `Uri` can impl `Deref<Target=str>`